### PR TITLE
If there's such lex rule "TOKEN_X : '\'' ( ESC | ~['\\] ) '\'' " , a …

### DIFF
--- a/src/main/java/de/flashpixx/rrd_antlr4/engine/template/IBaseTemplate.java
+++ b/src/main/java/de/flashpixx/rrd_antlr4/engine/template/IBaseTemplate.java
@@ -174,7 +174,7 @@ public abstract class IBaseTemplate implements ITemplate
      */
     protected static String removequotes( final String p_string )
     {
-        return ( p_string.startsWith( "'" ) ) && ( p_string.endsWith( "'" ) )
+        return ( p_string.startsWith( "'" ) ) && ( p_string.endsWith( "'" ) ) && ( p_string.length() >= 2 )
                ? p_string.substring( 1, p_string.length() - 1 )
                : p_string;
     }


### PR DESCRIPTION
…index out bound exception will be threw.